### PR TITLE
feat: harden Reset PWA for offline use

### DIFF
--- a/console-overlay.js
+++ b/console-overlay.js
@@ -4,25 +4,32 @@
     const url=new URL(location.href);
     if(url.searchParams.get('debug')!=='1') return;
     const pane=document.createElement('div');
-    pane.style.cssText='position:fixed;bottom:0;left:0;right:0;max-height:45%;overflow:auto;background:rgba(0,0,0,.8);color:#e9f0f7;font:12px/1.4 monospace;padding:8px;z-index:99999;border-top:1px solid #243040';
-    pane.innerHTML='<b>DEBUG CONSOLE</b> <button id="dbgClear" style="float:right">clear</button><div id="dbgOut"></div>';
+    pane.className='console-overlay';
+    const title=document.createElement('b');
+    title.textContent='DEBUG CONSOLE';
+    const clearBtn=document.createElement('button');
+    clearBtn.id='dbgClear';
+    clearBtn.className='dbgClear';
+    clearBtn.textContent='clear';
+    const out=document.createElement('div');
+    out.id='dbgOut';
+    pane.append(title,clearBtn,out);
     document.body.appendChild(pane);
-    const out=pane.querySelector('#dbgOut');
-    pane.querySelector('#dbgClear').addEventListener('click',()=>{out.textContent='';});
+    clearBtn.addEventListener('click',()=>{out.textContent='';});
     const orig={log:console.log,warn:console.warn,error:console.error};
     ['log','warn','error'].forEach(k=>{
       console[k]=(...args)=>{
         orig[k](...args);
         const d=document.createElement('div');
         d.textContent='['+k.toUpperCase()+'] '+args.map(a=>typeof a==='object'?JSON.stringify(a):String(a)).join(' ');
-        d.style.color=k==='error'?'#ff6b6b':(k==='warn'?'#ffd166':'#cfe6ff');
+        d.className='log-'+k;
         out.appendChild(d);
       };
     });
     window.addEventListener('error',e=>{
       const d=document.createElement('div');
       d.textContent='[ERROR] '+(e.message||e.toString());
-      d.style.color='#ff6b6b';
+      d.className='log-error';
       out.appendChild(d);
     });
     console.log('Overlay debug activé.');

--- a/debug.css
+++ b/debug.css
@@ -1,0 +1,8 @@
+body{font-family:-apple-system,Roboto,Inter,Segoe UI,Helvetica,Arial;background:#0f1216;color:#e9f0f7;margin:0;padding:16px}
+.card{background:#171b21;border:1px solid #243040;border-radius:12px;padding:14px;margin-bottom:12px}
+.row{display:flex;gap:8px;flex-wrap:wrap}
+.btn{padding:8px 12px;border:1px solid #243040;background:#223042;border-radius:10px;color:#cfe6ff;font-weight:700;cursor:pointer}
+.ok{color:#8be28b}.warn{color:#ffd166}.bad{color:#ff6b6b}
+table{border-collapse:collapse;width:100%}th,td{border:1px solid #243040;padding:8px;text-align:left}
+code{background:#0b1622;padding:2px 4px;border-radius:6px}
+.mt8{margin-top:8px}

--- a/debug.html
+++ b/debug.html
@@ -3,16 +3,9 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self'; script-src 'self'; object-src 'none'; base-uri 'self';">
 <title>RESET — Debug & Self‑tests</title>
-<style>
-  body{font-family:-apple-system,Roboto,Inter,Segoe UI,Helvetica,Arial;background:#0f1216;color:#e9f0f7;margin:0;padding:16px}
-  .card{background:#171b21;border:1px solid #243040;border-radius:12px;padding:14px;margin-bottom:12px}
-  .row{display:flex;gap:8px;flex-wrap:wrap}
-  .btn{padding:8px 12px;border:1px solid #243040;background:#223042;border-radius:10px;color:#cfe6ff;font-weight:700;cursor:pointer}
-  .ok{color:#8be28b}.warn{color:#ffd166}.bad{color:#ff6b6b}
-  table{border-collapse:collapse;width:100%}th,td{border:1px solid #243040;padding:8px;text-align:left}
-  code{background:#0b1622;padding:2px 4px;border-radius:6px}
-</style>
+<link rel="stylesheet" href="debug.css">
 </head>
 <body>
 <h1>RESET — Debug & Self‑tests</h1>
@@ -26,7 +19,7 @@
     <tr><th>LocalStorage</th><td id="ls"></td></tr>
     <tr><th>Caches</th><td id="caches"></td></tr>
   </table>
-  <div class="row" style="margin-top:8px">
+  <div class="row mt8">
     <button class="btn" id="btnResetSW">Reset SW</button>
     <button class="btn" id="btnClearLS">Vider LocalStorage (clé RESET)</button>
   </div>
@@ -35,7 +28,7 @@
 <div class="card">
   <h2>Self‑tests (fonctionnels)</h2>
   <div id="out"></div>
-  <div class="row" style="margin-top:8px">
+  <div class="row mt8">
     <button class="btn" id="btnRunAll">Lancer tous les tests</button>
   </div>
 </div>
@@ -45,73 +38,6 @@
   <div id="log"></div>
 </div>
 
-<script>
-(function(){
-  const logEl=document.getElementById('log');
-  const orig={log:console.log,warn:console.warn,error:console.error};
-  ['log','warn','error'].forEach(k=>{
-    console[k]=(...args)=>{
-      orig[k](...args);
-      const d=document.createElement('div');
-      d.textContent='['+k.toUpperCase()+'] '+args.map(a=>typeof a==='object'?JSON.stringify(a):String(a)).join(' ');
-      d.className=k==='error'?'bad':(k==='warn'?'warn':'');
-      logEl.appendChild(d);
-    };
-  });
-})();
-function esc(str){return String(str).replace(/[&<>"']/g,c=>({"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"}[c]));}
-function row(str,cls=''){const d=document.createElement('div');d.innerHTML=str;if(cls)d.className=cls;return d;}
-function ok(s){return `<span class="ok">✅ ${esc(s)}</span>`}
-function bad(s){return `<span class="bad">❌ ${esc(s)}</span>`}
-function warn(s){return `<span class="warn">⚠️ ${esc(s)}</span>`}
-
-document.getElementById('ua').textContent=navigator.userAgent;
-(async()=>{
-  try{const r=await fetch('manifest.webmanifest');document.getElementById('mani').innerHTML=r.ok?ok('manifest chargé'):bad('manifest introuvable');}
-  catch(e){document.getElementById('mani').innerHTML=bad('erreur de chargement');}
-})();
-(async()=>{
-  if('serviceWorker' in navigator){
-    const regs=await navigator.serviceWorker.getRegistrations();
-    document.getElementById('sw').innerHTML=regs.length?ok(regs.length+' SW enregistré(s)'):warn('aucun SW');
-  }else{
-    document.getElementById('sw').innerHTML=bad('non supporté');
-  }
-})();
-try{
-  const testKey='__rst__'+Math.random();
-  localStorage.setItem(testKey,'1');localStorage.removeItem(testKey);
-  const size=Object.keys(localStorage).reduce((n,k)=>n+(localStorage[k]?.length||0),0);
-  document.getElementById('ls').innerHTML=ok('ok ('+size+' chars stockés)');
-}catch(e){document.getElementById('ls').innerHTML=bad('indisponible: '+e);}
-(async()=>{
-  if(!('caches' in window)){document.getElementById('caches').innerHTML=warn('API Cache non dispo');return;}
-  const keys=await caches.keys();document.getElementById('caches').innerHTML=keys.length?ok(keys.join(', ')):warn('vide');
-})();
-
-document.getElementById('btnResetSW').addEventListener('click', resetSW);
-document.getElementById('btnClearLS').addEventListener('click', clearLS);
-document.getElementById('btnRunAll').addEventListener('click', runAll);
-
-async function resetSW(){
-  try{
-    if('serviceWorker' in navigator){
-      const regs=await navigator.serviceWorker.getRegistrations();
-      await Promise.all(regs.map(r=>r.unregister()));
-    }
-    if('caches' in window){
-      const keys=await caches.keys();
-      await Promise.all(keys.map(k=>caches.delete(k)));
-    }
-    alert('OK. Recharge maintenant la page principale.');
-  }catch(e){alert('Erreur lors du reset: '+e.message);}
-}
-function clearLS(){Object.keys(localStorage).filter(k=>k.toLowerCase().includes('reset')).forEach(k=>localStorage.removeItem(k));alert('LocalStorage RESET vidé.');}
-async function testLoginFlow(){const okLogin=typeof doLogin==='function'||typeof window.doLogin==='function';return okLogin?ok('méthode login présente (manuel)'):warn('méthode login non trouvée (ouvrir index.html)');}
-async function testHALT(){try{const r=await fetch('index.html');const tx=await r.text();const hasHALT=tx.includes('HALT')&&(tx.includes('hHungry')||tx.includes('HALT</h2>'));return hasHALT?ok('HALT présent dans index.html'):bad('HALT introuvable');}catch(e){return bad('lecture index.html impossible');}}
-async function testExportImport(){try{const blob=new Blob([JSON.stringify({test:true})],{type:'application/json'});return ok('Export JSON possible (simulé)');}catch(e){return bad('Blob JSON non supporté');}}
-async function testSW(){if(!('serviceWorker' in navigator))return warn('SW non supporté');try{const regs=await navigator.serviceWorker.getRegistrations();return regs.length?ok('SW enregistré'):warn('aucun SW');}catch(e){return bad('erreur SW');}}
-async function runAll(){const out=document.getElementById('out');out.innerHTML='';out.appendChild(row('1) Login: '+await testLoginFlow()));out.appendChild(row('2) HALT: '+await testHALT()));out.appendChild(row('3) Export/Import: '+await testExportImport()));out.appendChild(row('4) Service Worker: '+await testSW()));out.appendChild(row('— Termine en vérifiant manuellement Journal/Habitudes/Tâches.','muted'));}
-</script>
+<script src="debug.js" defer></script>
 </body>
 </html>

--- a/debug.js
+++ b/debug.js
@@ -1,0 +1,61 @@
+(function(){
+  const logEl=document.getElementById('log');
+  const orig={log:console.log,warn:console.warn,error:console.error};
+  ['log','warn','error'].forEach(k=>{
+    console[k]=(...args)=>{
+      orig[k](...args);
+      const d=document.createElement('div');
+      d.textContent='['+k.toUpperCase()+'] '+args.map(a=>typeof a==='object'?JSON.stringify(a):String(a)).join(' ');
+      d.className=k==='error'?'bad':(k==='warn'?'warn':'');
+      logEl.appendChild(d);
+    };
+  });
+})();
+function esc(str){return String(str).replace(/[&<>"']/g,c=>({"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"}[c]));}
+function set(elId,status,msg){const el=document.getElementById(elId);el.textContent=msg;el.className=status;}
+
+document.getElementById('ua').textContent=navigator.userAgent;
+(async()=>{
+  try{const r=await fetch('manifest.webmanifest');set('mani',r.ok?'ok':'bad',r.ok?'manifest chargé':'manifest introuvable');}
+  catch(e){set('mani','bad','erreur de chargement');}
+})();
+(async()=>{
+  if('serviceWorker' in navigator){
+    const regs=await navigator.serviceWorker.getRegistrations();
+    set('sw',regs.length?'ok':'warn',regs.length?regs.length+' SW enregistré(s)':'aucun SW');
+  }else{set('sw','bad','non supporté');}
+})();
+try{
+  const testKey='__rst__'+Math.random();
+  localStorage.setItem(testKey,'1');localStorage.removeItem(testKey);
+  const size=Object.keys(localStorage).reduce((n,k)=>n+(localStorage[k]?.length||0),0);
+  set('ls','ok','ok ('+size+' chars stockés)');
+}catch(e){set('ls','bad','indisponible: '+e);}
+(async()=>{
+  if(!('caches' in window)){set('caches','warn','API Cache non dispo');return;}
+  const keys=await caches.keys();set('caches',keys.length?'ok':'warn',keys.length?keys.join(', '):'vide');
+})();
+
+document.getElementById('btnResetSW').addEventListener('click', resetSW);
+document.getElementById('btnClearLS').addEventListener('click', clearLS);
+document.getElementById('btnRunAll').addEventListener('click', runAll);
+
+async function resetSW(){
+  try{
+    if('serviceWorker' in navigator){
+      const regs=await navigator.serviceWorker.getRegistrations();
+      await Promise.all(regs.map(r=>r.unregister()));
+    }
+    if('caches' in window){
+      const keys=await caches.keys();
+      await Promise.all(keys.map(k=>caches.delete(k)));
+    }
+    alert('OK. Recharge maintenant la page principale.');
+  }catch(e){alert('Erreur lors du reset: '+e.message);}
+}
+function clearLS(){Object.keys(localStorage).filter(k=>k.toLowerCase().includes('reset')).forEach(k=>localStorage.removeItem(k));alert('LocalStorage RESET vidé.');}
+async function testLoginFlow(){const okLogin=typeof doLogin==='function'||typeof window.doLogin==='function';return okLogin?['ok','méthode login présente (manuel)']:['warn','méthode login non trouvée (ouvrir index.html)'];}
+async function testHALT(){try{const r=await fetch('index.html');const tx=await r.text();const hasHALT=tx.includes('HALT')&&(tx.includes('hHungry')||tx.includes('HALT</h2>'));return hasHALT?['ok','HALT présent dans index.html']:['bad','HALT introuvable'];}catch(e){return ['bad','lecture index.html impossible'];}}
+async function testExportImport(){try{const blob=new Blob([JSON.stringify({test:true})],{type:'application/json'});return ['ok','Export JSON possible (simulé)'];}catch(e){return ['bad','Blob JSON non supporté'];}}
+async function testSW(){if(!('serviceWorker' in navigator))return ['warn','SW non supporté'];try{const regs=await navigator.serviceWorker.getRegistrations();return regs.length?['ok','SW enregistré']:['warn','aucun SW'];}catch(e){return ['bad','erreur SW'];}}
+async function runAll(){const out=document.getElementById('out');out.textContent='';const rows=[['1) Login: ',await testLoginFlow()],['2) HALT: ',await testHALT()],['3) Export/Import: ',await testExportImport()],['4) Service Worker: ',await testSW()]];rows.forEach(([label,[status,msg]])=>{const d=document.createElement('div');d.appendChild(document.createTextNode(label));const span=document.createElement('span');span.className=status;span.textContent=(status==='ok'?'✅ ':status==='bad'?'❌ ':'⚠️ ')+msg;d.appendChild(span);out.appendChild(d);});const end=document.createElement('div');end.className='muted';end.textContent='— Termine en vérifiant manuellement Journal/Habitudes/Tâches.';out.appendChild(end);}

--- a/index.html
+++ b/index.html
@@ -3,37 +3,11 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' 'unsafe-inline';">
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self'; script-src 'self'; object-src 'none'; base-uri 'self';">
 <title>RESET — Ismaël</title>
 <link rel="manifest" href="manifest.webmanifest">
 <link rel="apple-touch-icon" href="icon-192.png">
-<style>
-:root{
-  --bg:#0f1216; --card:#171b21; --muted:#8da2b3; --text:#e9f0f7;
-  --accent:#4da3ff; --danger:#ff6b6b; --warn:#ffd166; --ok:#8be28b; --line:#243040; --chip:#223042;
-}
-[data-theme="light"]{
-  --bg:#f7fbff; --card:#ffffff; --muted:#5b6b78; --text:#0b1a2b;
-  --accent:#2b74d8; --danger:#c54242; --warn:#b8860b; --ok:#2c8d2c; --line:#dde7f1; --chip:#eef4fb;
-}
-*{box-sizing:border-box}
-html,body{height:100%}
-body{margin:0;font-family:-apple-system,BlinkMacSystemFont,Roboto,Inter,Segoe UI,Helvetica,Arial;background:var(--bg);color:var(--text);}
-header{position:sticky;top:0;z-index:10;background:rgba(15,18,22,.8);backdrop-filter:blur(10px);border-bottom:1px solid var(--line);}
-[data-theme="light"] header{background:rgba(255,255,255,.8);}
-.bar{max-width:1100px;margin:0 auto;display:flex;align-items:center;gap:10px;padding:10px 16px;}
-.logo{font-weight:800;letter-spacing:.5px;font-size:18px}
-.nav{display:flex;gap:8px;flex-wrap:wrap;margin-left:auto}
-.nav button,.icon-btn{background:transparent;color:var(--muted);border:1px solid var(--line);padding:8px 10px;border-radius:10px;cursor:pointer;font-weight:600;}
-.nav button.active{color:var(--text);border-color:var(--accent);background:rgba(77,163,255,.12)}
-main{max-width:1100px;margin:16px auto;padding:12px}
-.card{background:var(--card);border:1px solid var(--line);border-radius:14px;padding:14px;}
-.right{display:flex;justify-content:flex-end}
-.btn{background:var(--chip);color:var(--text);border:1px solid var(--line);padding:8px 12px;border-radius:10px;cursor:pointer;font-weight:600;}
-.btn.ok{border-color:var(--ok);background:rgba(139,226,139,.12);color:var(--ok);}
-.muted{color:var(--muted);} .small{font-size:13px}
-.hidden{display:none}
-</style>
+<link rel="stylesheet" href="style.css">
 </head>
 <body>
 <header>
@@ -60,32 +34,7 @@ main{max-width:1100px;margin:16px auto;padding:12px}
   <!-- contenu principal rendu côté client -->
 </main>
 
-<script>
-const today=()=>new Date().toISOString().slice(0,10);
-function esc(str){return String(str).replace(/[&<>"']/g,c=>({"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"}[c]));}
-
-const state={theme:'dark'};
-function applyTheme(){document.documentElement.setAttribute('data-theme',state.theme);}
-function toggleTheme(){state.theme=state.theme==='light'?'dark':'light';applyTheme();}
-function doLogin(){
-  const u=document.getElementById('lu').value.trim();
-  const p=document.getElementById('lp').value;
-  if(u==='Ismael' && p==='Bymemu48.'){
-    document.getElementById('login').style.display='none';
-    document.getElementById('app').classList.remove('hidden');
-  }else{
-    document.getElementById('lockMsg').textContent='Identifiants incorrects.';
-  }
-}
-
-document.getElementById('loginBtn').addEventListener('click',doLogin);
-document.getElementById('themeBtn').addEventListener('click',toggleTheme);
-applyTheme();
-
-if('serviceWorker' in navigator){
-  navigator.serviceWorker.register('./sw.js?v=5').catch(console.error);
-}
-</script>
+<script src="main.js" defer></script>
 <script src="console-overlay.js" defer></script>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,24 @@
+const today=()=>new Date().toISOString().slice(0,10);
+function esc(str){return String(str).replace(/[&<>"']/g,c=>({"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"}[c]));}
+
+const state={theme:'dark'};
+function applyTheme(){document.documentElement.setAttribute('data-theme',state.theme);}
+function toggleTheme(){state.theme=state.theme==='light'?'dark':'light';applyTheme();}
+function doLogin(){
+  const u=document.getElementById('lu').value.trim();
+  const p=document.getElementById('lp').value;
+  if(u==='Ismael' && p==='Bymemu48.'){
+    document.getElementById('login').style.display='none';
+    document.getElementById('app').classList.remove('hidden');
+  }else{
+    document.getElementById('lockMsg').textContent='Identifiants incorrects.';
+  }
+}
+
+document.getElementById('loginBtn').addEventListener('click',doLogin);
+document.getElementById('themeBtn').addEventListener('click',toggleTheme);
+applyTheme();
+
+if('serviceWorker' in navigator){
+  navigator.serviceWorker.register('./sw.js').catch(console.error);
+}

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,11 +1,11 @@
 {
   "name": "RESET — Ismaël",
   "short_name": "RESET",
-  "start_url": "./",
+  "start_url": "/Reset/",
   "display": "standalone",
   "background_color": "#0f1216",
   "theme_color": "#0f1216",
-  "scope": "./",
+  "scope": "/Reset/",
   "description": "Outil RESET offline",
   "icons": [
     { "src": "icon-192.png", "sizes": "192x192", "type": "image/png" },

--- a/reset.html
+++ b/reset.html
@@ -3,28 +3,12 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self'; script-src 'self'; object-src 'none'; base-uri 'self';">
 <title>Reset SW</title>
+<link rel="stylesheet" href="style.css">
 </head>
 <body>
 <h1>Reset service worker & caches…</h1>
-<script>
-(async () => {
-  try {
-    if ('serviceWorker' in navigator) {
-      const regs = await navigator.serviceWorker.getRegistrations();
-      await Promise.all(regs.map(r => r.unregister()));
-    }
-    if ('caches' in window) {
-      const keys = await caches.keys();
-      await Promise.all(keys.map(k => caches.delete(k)));
-    }
-    const p = document.createElement('p');
-    p.textContent = 'OK. Recharge maintenant la page principale.';
-    document.body.appendChild(p);
-  } catch (e) {
-    alert('Erreur lors du reset: ' + e.message);
-  }
-})();
-</script>
+<script src="reset.js" defer></script>
 </body>
 </html>

--- a/reset.js
+++ b/reset.js
@@ -1,0 +1,17 @@
+(async () => {
+  try {
+    if ('serviceWorker' in navigator) {
+      const regs = await navigator.serviceWorker.getRegistrations();
+      await Promise.all(regs.map(r => r.unregister()));
+    }
+    if ('caches' in window) {
+      const keys = await caches.keys();
+      await Promise.all(keys.map(k => caches.delete(k)));
+    }
+    const p = document.createElement('p');
+    p.textContent = 'OK. Recharge maintenant la page principale.';
+    document.body.appendChild(p);
+  } catch (e) {
+    alert('Erreur lors du reset: ' + e.message);
+  }
+})();

--- a/style.css
+++ b/style.css
@@ -1,0 +1,32 @@
+:root{
+  --bg:#0f1216; --card:#171b21; --muted:#8da2b3; --text:#e9f0f7;
+  --accent:#4da3ff; --danger:#ff6b6b; --warn:#ffd166; --ok:#8be28b; --line:#243040; --chip:#223042;
+}
+[data-theme="light"]{
+  --bg:#f7fbff; --card:#ffffff; --muted:#5b6b78; --text:#0b1a2b;
+  --accent:#2b74d8; --danger:#c54242; --warn:#b8860b; --ok:#2c8d2c; --line:#dde7f1; --chip:#eef4fb;
+}
+*{box-sizing:border-box}
+html,body{height:100%}
+body{margin:0;font-family:-apple-system,BlinkMacSystemFont,Roboto,Inter,Segoe UI,Helvetica,Arial;background:var(--bg);color:var(--text);}
+header{position:sticky;top:0;z-index:10;background:rgba(15,18,22,.8);backdrop-filter:blur(10px);border-bottom:1px solid var(--line);}
+[data-theme="light"] header{background:rgba(255,255,255,.8);}
+.bar{max-width:1100px;margin:0 auto;display:flex;align-items:center;gap:10px;padding:10px 16px;}
+.logo{font-weight:800;letter-spacing:.5px;font-size:18px}
+.nav{display:flex;gap:8px;flex-wrap:wrap;margin-left:auto}
+.nav button,.icon-btn{background:transparent;color:var(--muted);border:1px solid var(--line);padding:8px 10px;border-radius:10px;cursor:pointer;font-weight:600;}
+.nav button.active{color:var(--text);border-color:var(--accent);background:rgba(77,163,255,.12)}
+main{max-width:1100px;margin:16px auto;padding:12px}
+.card{background:var(--card);border:1px solid var(--line);border-radius:14px;padding:14px;}
+.right{display:flex;justify-content:flex-end}
+.btn{background:var(--chip);color:var(--text);border:1px solid var(--line);padding:8px 12px;border-radius:10px;cursor:pointer;font-weight:600;}
+.btn.ok{border-color:var(--ok);background:rgba(139,226,139,.12);color:var(--ok);}
+.muted{color:var(--muted);} .small{font-size:13px}
+.hidden{display:none}
+
+/* Console overlay */
+.console-overlay{position:fixed;bottom:0;left:0;right:0;max-height:45%;overflow:auto;background:rgba(0,0,0,.8);color:#e9f0f7;font:12px/1.4 monospace;padding:8px;z-index:99999;border-top:1px solid #243040;}
+.console-overlay .dbgClear{float:right;}
+.console-overlay .log-error{color:#ff6b6b;}
+.console-overlay .log-warn{color:#ffd166;}
+.console-overlay .log-log{color:#cfe6ff;}

--- a/sw.js
+++ b/sw.js
@@ -1,9 +1,16 @@
-const CACHE = 'reset-cache-v5';
+// Simple offline cache with versioned assets
+const CACHE = 'CACHE_V1';
 const ASSETS = [
   './',
   './index.html',
   './debug.html',
   './reset.html',
+  './style.css',
+  './debug.css',
+  './main.js',
+  './debug.js',
+  './reset.js',
+  './console-overlay.js',
   './manifest.webmanifest',
   './icon-192.png',
   './icon-512.png'


### PR DESCRIPTION
## Summary
- externalize inline styles/scripts and enforce strict Content-Security-Policy
- replace innerHTML/inline handlers with safe DOM updates and event listeners
- version service worker cache and precache app assets for offline use

## Testing
- `node -e "console.log('No automated tests provided')"`

------
https://chatgpt.com/codex/tasks/task_e_68a2700367f48327bfe6dc131b281ddd