### PR TITLE
Improve login flow and debugging helpers

### DIFF
--- a/debug.js
+++ b/debug.js
@@ -11,6 +11,8 @@
     };
   });
 })();
+window.addEventListener('error',e=>console.error('Erreur script:',e.message));
+window.addEventListener('unhandledrejection',e=>console.error('Rejet non géré:',e.reason));
 function esc(str){return String(str).replace(/[&<>"']/g,c=>({"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"}[c]));}
 function set(elId,status,msg){const el=document.getElementById(elId);el.textContent=msg;el.className=status;}
 
@@ -50,10 +52,23 @@ async function resetSW(){
       const keys=await caches.keys();
       await Promise.all(keys.map(k=>caches.delete(k)));
     }
+    console.log('Service worker et caches réinitialisés');
     alert('OK. Recharge maintenant la page principale.');
-  }catch(e){alert('Erreur lors du reset: '+e.message);}
+  }catch(e){
+    console.error('Erreur lors du reset SW',e);
+    alert('Erreur lors du reset: '+e.message);
+  }
 }
-function clearLS(){Object.keys(localStorage).filter(k=>k.toLowerCase().includes('reset')).forEach(k=>localStorage.removeItem(k));alert('LocalStorage RESET vidé.');}
+function clearLS(){
+  try{
+    Object.keys(localStorage).filter(k=>k.toLowerCase().includes('reset')).forEach(k=>localStorage.removeItem(k));
+    console.log('LocalStorage RESET vidé.');
+    alert('LocalStorage RESET vidé.');
+  }catch(e){
+    console.error('Erreur clearLS',e);
+    alert('Erreur lors du vidage du LocalStorage.');
+  }
+}
 async function testLoginFlow(){const okLogin=typeof doLogin==='function'||typeof window.doLogin==='function';return okLogin?['ok','méthode login présente (manuel)']:['warn','méthode login non trouvée (ouvrir index.html)'];}
 async function testHALT(){try{const r=await fetch('index.html');const tx=await r.text();const hasHALT=tx.includes('HALT')&&(tx.includes('hHungry')||tx.includes('HALT</h2>'));return hasHALT?['ok','HALT présent dans index.html']:['bad','HALT introuvable'];}catch(e){return ['bad','lecture index.html impossible'];}}
 async function testExportImport(){try{const blob=new Blob([JSON.stringify({test:true})],{type:'application/json'});return ['ok','Export JSON possible (simulé)'];}catch(e){return ['bad','Blob JSON non supporté'];}}

--- a/main.js
+++ b/main.js
@@ -2,23 +2,44 @@ const today=()=>new Date().toISOString().slice(0,10);
 function esc(str){return String(str).replace(/[&<>"']/g,c=>({"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"}[c]));}
 
 const state={theme:'dark'};
+const views=['Dashboard','3R','Journal','Habitudes','Tâches','Contrat','HALT','Données'];
 function applyTheme(){document.documentElement.setAttribute('data-theme',state.theme);}
 function toggleTheme(){state.theme=state.theme==='light'?'dark':'light';applyTheme();}
+function buildNav(){
+  const nav=document.getElementById('nav');
+  nav.innerHTML='';
+  views.forEach(v=>{
+    const btn=document.createElement('button');
+    btn.textContent=v;btn.dataset.view=v;nav.appendChild(btn);
+  });
+}
+function showView(name){
+  const app=document.getElementById('app');
+  app.innerHTML='<h2>'+esc(name)+'</h2>';
+}
 function doLogin(){
   const u=document.getElementById('lu').value.trim();
   const p=document.getElementById('lp').value;
   if(u==='Ismael' && p==='Bymemu48.'){
     document.getElementById('login').style.display='none';
-    document.getElementById('app').classList.remove('hidden');
+    const app=document.getElementById('app');
+    app.classList.remove('hidden');
+    buildNav();
+    showView('Dashboard');
   }else{
     document.getElementById('lockMsg').textContent='Identifiants incorrects.';
   }
 }
 
-document.getElementById('loginBtn').addEventListener('click',doLogin);
-document.getElementById('themeBtn').addEventListener('click',toggleTheme);
-applyTheme();
-
-if('serviceWorker' in navigator){
-  navigator.serviceWorker.register('./sw.js').catch(console.error);
-}
+document.addEventListener('DOMContentLoaded',()=>{
+  document.getElementById('loginBtn').addEventListener('click',doLogin);
+  document.getElementById('themeBtn').addEventListener('click',toggleTheme);
+  document.getElementById('nav').addEventListener('click',e=>{
+    const btn=e.target.closest('button[data-view]');
+    if(btn)showView(btn.dataset.view);
+  });
+  applyTheme();
+  if('serviceWorker' in navigator){
+    navigator.serviceWorker.register('./sw.js').catch(console.error);
+  }
+});


### PR DESCRIPTION
## Summary
- Build navigation automatically after login and default to Dashboard view
- Attach UI events on DOMContentLoaded and preserve CSP compatibility
- Enhance debug tools with clearer error reporting and reset logs

## Testing
- `node --check main.js`
- `node --check debug.js`


------
https://chatgpt.com/codex/tasks/task_e_68a278cc84f48327a199a2b73b6d1ecd